### PR TITLE
Fix problems introduced by merging

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -50,12 +50,12 @@ def test_method_correct_argtypes():
 def test_method_args():
     registry = Registry()
 
-    @registry.method(some_text=str, some_number=int)
+    @registry.method(returns=str, some_text=str, some_number=int)
     def foo(some_text, some_number, *args):
         return some_text + str(some_number) + str(args)
     assert foo("Hi", 5, 6, "Test") == "Hi5(6, 'Test')"
 
-    @registry.method(some_text=str, some_number=int)
+    @registry.method(returns=str, some_text=str, some_number=int)
     def bar(some_text, some_number, *args, **kwargs):
         return some_text + str(some_number) + str(args) + str(kwargs)
     assert bar("Hi", 5, "foo", bla=6, stuff="Test") == "Hi5('foo',){'stuff': 'Test', 'bla': 6}"
@@ -66,7 +66,7 @@ def test_method_args():
 def test_method_defaults():
     registry = Registry()
 
-    @registry.method(some_number=int, some_text=str)
+    @registry.method(returns=str, some_number=int, some_text=str)
     def foo(some_number, some_text="Test"):
         return some_text
     assert foo(5) == "Test"

--- a/typedjsonrpc/registry.py
+++ b/typedjsonrpc/registry.py
@@ -73,10 +73,13 @@ class Registry(object):
             argument_names = inspect.getargspec(func).args
             defaults = inspect.getargspec(func).defaults
             arguments = self._collect_arguments(argument_names, args, kwargs, defaults)
-            self._check_types(arguments, argtypes)
+
+            argument_types = argtypes.copy()
+            return_type = argument_types.pop(RETURNS_KEY)
+            self._check_types(arguments, argument_types)
 
             result = func(*args, **kwargs)
-            self._check_return_type(result, argtypes[RETURNS_KEY])
+            self._check_return_type(result, return_type)
 
             return result
 
@@ -145,14 +148,14 @@ class Registry(object):
         :param type_declarations: Argument type by name
         :type type_declarations: dict[str, type]
         """
-        if len(argument_names) != len(type_declarations) - 1:
-            raise Exception("Number of function arguments (%s) does not match number of "
-                            "declared types (%s)"
-                            % (len(argument_names), len(type_declarations) - 1))
         if RETURNS_KEY in argument_names:
             raise Exception("'%s' may not be used as an argument name" % (RETURNS_KEY,))
         if RETURNS_KEY not in type_declarations:
             raise Exception("Missing return type declaration")
+        if len(argument_names) != len(type_declarations) - 1:
+            raise Exception("Number of function arguments (%s) does not match number of "
+                            "declared types (%s)"
+                            % (len(argument_names), len(type_declarations) - 1))
         for arg in argument_names:
             if arg not in type_declarations:
                 raise Exception("Argument '%s' does not have a declared type" % (arg,))


### PR DESCRIPTION
Some tests were missing return type declarations and the registry didn't correctly deal with the return type declarations.
