### PR TITLE
Disallow registering class methods

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -15,6 +15,17 @@ def test_register():
     assert registry._name_to_method_info["bar"].method == foo
 
 
+def test_register_class_method():
+    registry = Registry()
+
+    class Foo(object):
+        def bar(self):
+            pass
+    baz = Foo()
+    with pytest.raises(Exception):
+        registry.register("42", baz.bar)
+
+
 def test_method():
     registry = Registry()
 

--- a/typedjsonrpc/registry.py
+++ b/typedjsonrpc/registry.py
@@ -18,7 +18,15 @@ class Registry(object):
 
     def __init__(self):
         self._name_to_method_info = {}
-        self.register("rpc.describe", self.describe, self._get_signature([], {"returns": dict}))
+        self._register_describe()
+
+    def _register_describe(self):
+        def _describe():
+            self.describe()
+        _describe.__doc__ = self.describe.__doc__
+
+        describe_signature = self._get_signature([], {"returns": dict})
+        self.register("rpc.describe", _describe, describe_signature)
 
     def dispatch(self, request):
         """Takes a request and dispatches its data to a jsonrpc method.
@@ -58,6 +66,8 @@ class Registry(object):
         :param signature: List of the argument names and types
         :type signature: list[str, type]
         """
+        if inspect.ismethod(method):
+            raise Exception("typedjsonrpc does not support making class methods into endpoints")
         self._name_to_method_info[name] = MethodInfo(name, method, signature)
 
     def method(self, **argtypes):


### PR DESCRIPTION
This fixes rpc.describe and registering class methods. See Issue #22 
