### PR TITLE
Ensure sent data is converted to a string

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -206,7 +206,7 @@ class TestDispatch(object):
     @staticmethod
     def _create_fake_request(data):
         class FakeRequest(object):
-            def get_data(self):
+            def get_data(self, as_text=False):
                 return json.dumps(data)
         return FakeRequest()
 
@@ -343,7 +343,7 @@ class TestDispatch(object):
         registry = Registry()
 
         class FakeRequest(object):
-            def get_data(self):
+            def get_data(self, as_text=False):
                 return '{ "jsonrpc": "2.0", "method":, "id":]'
 
         fake_request = FakeRequest()

--- a/typedjsonrpc/registry.py
+++ b/typedjsonrpc/registry.py
@@ -267,7 +267,7 @@ class Registry(object):
         :return: The parsed json object
         :rtype: dict[str, object]
         """
-        data = request.get_data()
+        data = request.get_data(as_text=True)
         try:
             msg = json.loads(data)
         except Exception:


### PR DESCRIPTION
In Python 3, json.loads cannot parse bytes. However, in Python 2,
str can be parsed by json.loads. We can simply just ensure that we
only read text.
