### PR TITLE
Stringify wrapped exceptions if non-json-serializable

### DIFF
--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,32 @@
+#
+# Copyright 2015 Palantir Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+from typedjsonrpc.errors import InternalError
+
+
+class TestInternalError(object):
+
+    def test_from_error(self):
+        class NonSerializableObject(object):
+            pass
+        try:
+            e = Exception()
+            e.random = NonSerializableObject()
+            raise e
+        except Exception as exc:
+            wrapped_exc = InternalError.from_error(exc, json.JSONEncoder)
+            json.dumps(wrapped_exc.as_error_object())

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -14,19 +14,29 @@
 # limitations under the License.
 
 import json
+import sys
 
 from typedjsonrpc.errors import InternalError
 
 
 class TestInternalError(object):
 
-    def test_from_error(self):
+    def test_from_error_not_serializable(self):
         class NonSerializableObject(object):
             pass
         try:
             e = Exception()
             e.random = NonSerializableObject()
             raise e
-        except Exception as exc:
-            wrapped_exc = InternalError.from_error(exc, json.JSONEncoder)
+        except Exception:
+            wrapped_exc = InternalError.from_error(sys.exc_info(), json.JSONEncoder)
+            json.dumps(wrapped_exc.as_error_object())
+
+    def test_from_error_serializable(self):
+        try:
+            e = Exception()
+            e.random = {"foo": "bar"}
+            raise e
+        except Exception:
+            wrapped_exc = InternalError.from_error(sys.exc_info(), json.JSONEncoder)
             json.dumps(wrapped_exc.as_error_object())

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -621,7 +621,6 @@ class TestDispatch(object):
         response = json.loads(registry.dispatch(fake_request))
         assert isinstance(response, dict)
         assert "error" in response
-        assert response["error"]
         assert isinstance(response["error"]["data"]["random"], six.string_types)
         assert NonSerializableObject.__name__ in response["error"]["data"]["random"]
 
@@ -644,7 +643,6 @@ class TestDispatch(object):
         response = json.loads(registry.dispatch(fake_request))
         assert isinstance(response, dict)
         assert "error" in response
-        assert response["error"]
         assert random_val == response["error"]["data"]["random"]
 
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -601,6 +601,30 @@ class TestDispatch(object):
         fake_request = self._create_fake_request([])
         assert registry.dispatch(fake_request) is None
 
+    def test_non_serializable_exception(self):
+        registry = Registry()
+
+        class NonSerializableObject(object):
+            pass
+
+        @registry.method(returns=None)
+        def raise_exception():
+            e = Exception()
+            e.random = NonSerializableObject()
+            raise e
+
+        fake_request = self._create_fake_request({
+            "jsonrpc": "2.0",
+            "method": "test_registry.raise_exception",
+            "id": "bogus",
+        })
+        response = json.loads(registry.dispatch(fake_request))
+        assert isinstance(response, dict)
+        assert "error" in response
+        assert response["error"]
+        assert isinstance(response["error"]["data"]["random"], six.string_types)
+        assert NonSerializableObject.__name__ in response["error"]["data"]["random"]
+
 
 def test_describe():
     registry = Registry()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -625,6 +625,28 @@ class TestDispatch(object):
         assert isinstance(response["error"]["data"]["random"], six.string_types)
         assert NonSerializableObject.__name__ in response["error"]["data"]["random"]
 
+    def test_serializable_exception(self):
+        registry = Registry()
+
+        random_val = {"foo": "bar"}
+
+        @registry.method(returns=None)
+        def raise_exception():
+            e = Exception()
+            e.random = random_val
+            raise e
+
+        fake_request = self._create_fake_request({
+            "jsonrpc": "2.0",
+            "method": "test_registry.raise_exception",
+            "id": "bogus",
+        })
+        response = json.loads(registry.dispatch(fake_request))
+        assert isinstance(response, dict)
+        assert "error" in response
+        assert response["error"]
+        assert random_val == response["error"]["data"]["random"]
+
 
 def test_describe():
     registry = Registry()

--- a/typedjsonrpc/errors.py
+++ b/typedjsonrpc/errors.py
@@ -67,13 +67,23 @@ class InternalError(Error):
     message = "Internal error"
 
     @staticmethod
-    def from_error(exc, debug_url=None):
+    def from_error(exc, json_encoder, debug_url=None):
         """Wraps another Exception in an InternalError.
 
         :type exc: Exception
+        :type json_encoder: json.JSONEncoder
+        :type debug_url: str | None
         :rtype: InternalError
+
+        .. versionchanged:: 0.2.0
+            Stringifies non-JSON-serializable objects
         """
         data = exc.__dict__.copy()
+        for key, value in data.items():
+            try:
+                json_encoder.encode(value)
+            except TypeError:
+                data[key] = repr(value)
         data["traceback"] = "".join(traceback.format_exception(*sys.exc_info()))
         if debug_url is not None:
             data["debug_url"] = debug_url

--- a/typedjsonrpc/errors.py
+++ b/typedjsonrpc/errors.py
@@ -15,7 +15,6 @@
 
 """Error classes for typedjsonrpc."""
 import traceback
-import sys
 
 
 class Error(Exception):
@@ -67,10 +66,11 @@ class InternalError(Error):
     message = "Internal error"
 
     @staticmethod
-    def from_error(exc, json_encoder, debug_url=None):
+    def from_error(exc_info, json_encoder, debug_url=None):
         """Wraps another Exception in an InternalError.
 
-        :type exc: Exception
+        :param exc_info: The exception info for the wrapped exception
+        :type exc_info: (type, object, traceback)
         :type json_encoder: json.JSONEncoder
         :type debug_url: str | None
         :rtype: InternalError
@@ -78,13 +78,14 @@ class InternalError(Error):
         .. versionchanged:: 0.2.0
             Stringifies non-JSON-serializable objects
         """
+        exc = exc_info[1]
         data = exc.__dict__.copy()
         for key, value in data.items():
             try:
                 json_encoder.encode(value)
             except TypeError:
                 data[key] = repr(value)
-        data["traceback"] = "".join(traceback.format_exception(*sys.exc_info()))
+        data["traceback"] = "".join(traceback.format_exception(*exc_info))
         if debug_url is not None:
             data["debug_url"] = debug_url
         return InternalError(data)

--- a/typedjsonrpc/registry.py
+++ b/typedjsonrpc/registry.py
@@ -115,7 +115,7 @@ class Registry(object):
                     debug_url = self._store_traceback()
                 else:
                     debug_url = None
-                new_error = InternalError.from_error(exc, debug_url)
+                new_error = InternalError.from_error(exc, self.json_encoder, debug_url)
                 return Registry._create_error_response(msg_id, new_error)
 
     def _store_traceback(self):

--- a/typedjsonrpc/registry.py
+++ b/typedjsonrpc/registry.py
@@ -17,6 +17,7 @@
 import inspect
 import json
 import six
+import sys
 import typedjsonrpc.parameter_checker as parameter_checker
 import wrapt
 
@@ -111,11 +112,12 @@ class Registry(object):
                 return Registry._create_error_response(msg_id, exc)
         except Exception as exc:  # pylint: disable=broad-except
             if not is_notification:
+                exc_info = sys.exc_info()
                 if self.debug:
                     debug_url = self._store_traceback()
                 else:
                     debug_url = None
-                new_error = InternalError.from_error(exc, self.json_encoder, debug_url)
+                new_error = InternalError.from_error(exc_info, self.json_encoder, debug_url)
                 return Registry._create_error_response(msg_id, new_error)
 
     def _store_traceback(self):


### PR DESCRIPTION
Since JSON-RPC error messages try to be helpful, we include as much
of the original exception as possible. We can use "repr" to enforce
that non-serializable objects will also return valid error messages.

This fixes issue #51.