### PR TITLE
Fix docs versioning

### DIFF
--- a/contrib/build-docs.sh
+++ b/contrib/build-docs.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Copyright 2016 Palantir Technologies, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ROOT_DIR="$(cd "$(dirname "$0")"/.. && pwd)"
+(
+    cd "$ROOT_DIR/docs/"
+    make clean html
+)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,7 +56,7 @@ copyright = u"2015, Palantir Technologies, Inc"
 # the built documents.
 #
 # The short X.Y version.
-version = typedjsonrpc.__version__.split(maxsplit=3)[:2]
+version = ".".join(typedjsonrpc.__version__.split(".", 3)[:2])
 # The full version, including alpha/beta/rc tags.
 release = typedjsonrpc.__version__
 


### PR DESCRIPTION
1. Fix versioning to work in Python 2 since maxsplit is not a keyword
   argument in "".split.
2. Concatenate version pieces back into a string
3. Add in build-docs.sh for ease of using tox to build docs
