### PR TITLE
Add strict_floats flag to Registry

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -290,3 +290,46 @@ Example:
     @registry.method(returns=list)
     def get_headers():
         return list(current_request.headers)
+
+Disabling strictness of floats
+------------------------------
+``typedjsonrpc`` by default will only accept floats into a `float` typed parameter. For example, if
+your function were this:
+
+.. code-block:: python
+
+    import math
+
+    @registry.method(returns=int, x=float)
+    def floor(x):
+        return int(math.floor(x))
+
+and your input were this::
+
+    {
+        "jsonrpc": "2.0",
+        "method": "floor",
+        "params": {
+            "x": 1
+        },
+        "id": "foo"
+    }
+
+You would get an invalid param error like this::
+
+    {
+        "error": {
+            "code": -32602,
+            "data": {
+                "debug_url": "/debug/4456954960",
+                "message": "Value '1' for parameter 'x' is not of expected type <type 'float'>."
+            },
+            "message": "Invalid params"
+        },
+        "id": "foo",
+        "jsonrpc": "2.0"
+    }
+
+This can actually frequently come up when you use a JSON encoder. A JSON encoder may choose to write
+the float ``1.0`` as an integer ``1``. In order to get around this, you can manually edit the JSON
+or set ``strict_floats`` to ``False`` in your `typedjsonrpc.registry.Registry`.

--- a/tests/test_parameter_checker.py
+++ b/tests/test_parameter_checker.py
@@ -87,3 +87,17 @@ def test_no_defaults():
     parameter_checker.validate_params_match(foo, {"a": "bar"})
     with pytest.raises(InvalidParamsError):
         parameter_checker.validate_params_match(foo, {"a": "bar", "b": "baz"})
+
+
+class TestIsInstance(object):
+    def test_strict_floats(self):
+        assert parameter_checker._is_instance(1.0, float, strict_floats=True)
+        assert not parameter_checker._is_instance(1, float, strict_floats=True)
+        # This is a long in Python 2
+        assert not parameter_checker._is_instance(1000000000000000000000, float, strict_floats=True)
+
+    def test_non_strict_floats(self):
+        assert parameter_checker._is_instance(1.0, float, strict_floats=False)
+        assert parameter_checker._is_instance(1, float, strict_floats=False)
+        # This is a long in Python 2
+        assert parameter_checker._is_instance(1000000000000000000000, float, strict_floats=False)

--- a/typedjsonrpc/parameter_checker.py
+++ b/typedjsonrpc/parameter_checker.py
@@ -55,18 +55,20 @@ def validate_params_match(method, parameters):
             raise InvalidParamsError("Too many parameters")
 
 
-def check_types(parameters, parameter_types):
+def check_types(parameters, parameter_types, strict_floats):
     """Checks that the given parameters have the correct types.
 
     :param parameters: List of (name, value) pairs of the given parameters
     :type parameters: dict[str, object]
     :param parameter_types: Parameter type by name.
     :type parameter_types: dict[str, type]
+    :param strict_floats: If False, treat integers as floats
+    :type strict_floats: bool
     """
     for name, parameter_type in parameter_types.items():
         if name not in parameters:
             raise InvalidParamsError("Parameter '{}' is missing.".format(name))
-        if not _is_instance(parameters[name], parameter_type):
+        if not _is_instance(parameters[name], parameter_type, strict_floats):
             raise InvalidParamsError("Value '{}' for parameter '{}' is not of expected type {}."
                                      .format(parameters[name], name, parameter_type))
 
@@ -88,25 +90,29 @@ def check_type_declaration(parameter_names, parameter_types):
             raise Exception("Parameter '{}' does not have a declared type".format(parameter_name))
 
 
-def check_return_type(value, expected_type):
+def check_return_type(value, expected_type, strict_floats):
     """Checks that the given return value has the correct type.
 
     :param value: Value returned by the method
     :type value: object
     :param expected_type: Expected return type
     :type expected_type: type
+    :param strict_floats: If False, treat integers as floats
+    :type strict_floats: bool
     """
     if expected_type is None:
         if value is not None:
             raise InvalidReturnTypeError("Returned value is '{}' but None was expected"
                                          .format(value))
-    elif not _is_instance(value, expected_type):
+    elif not _is_instance(value, expected_type, strict_floats):
         raise InvalidReturnTypeError("Type of return value '{}' does not match expected type {}"
                                      .format(value, expected_type))
 
 
-def _is_instance(value, expected_type):
-    if expected_type is int:
+def _is_instance(value, expected_type, strict_floats):
+    if expected_type is float and not strict_floats:
+        return isinstance(value, (six.integer_types, float))
+    if expected_type in six.integer_types:
         return isinstance(value, six.integer_types)
-    else:
-        return isinstance(value, expected_type)
+
+    return isinstance(value, expected_type)

--- a/typedjsonrpc/registry.py
+++ b/typedjsonrpc/registry.py
@@ -66,14 +66,21 @@ class Registry(object):
     .. versionchanged:: 0.2.0 Changed from class to instance
     """
 
-    def __init__(self, debug=False):
+    def __init__(self,
+                 debug=False,
+                 strict_floats=True):
         """
         :param debug: If True, the registry records tracebacks for debugging purposes
         :type debug: bool
+        :param strict_floats: If True, the registry does not autocast floats into ints
+        :type strict_floats: bool
+
+        .. versionchanged:: 0.4.0 Added strict_floats option
         """
         self._name_to_method_info = {}
         self._register_describe()
         self.debug = debug
+        self._strict_floats = strict_floats
         self._logger = _get_default_logger()
         self.tracebacks = {}
 
@@ -257,10 +264,10 @@ class Registry(object):
             defaults = inspect.getargspec(method).defaults  # pylint: disable=deprecated-method
             parameters = self._collect_parameters(parameter_names, args, kwargs, defaults)
 
-            parameter_checker.check_types(parameters, parameter_types)
+            parameter_checker.check_types(parameters, parameter_types, self._strict_floats)
 
             result = method(*args, **kwargs)
-            parameter_checker.check_return_type(result, returns)
+            parameter_checker.check_return_type(result, returns, self._strict_floats)
 
             return result
 


### PR DESCRIPTION
strict_floats allows users to customize the treatment of ints in a float
field. strict_floats is by default on to match previous behavior.

Fix for issue #71 
