### PR TITLE
Switched 404 URLs to point to PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,16 +17,16 @@
 typedjsonrpc
 ============
 .. image:: https://img.shields.io/pypi/status/typedjsonrpc.svg
-     :target: https://img.shields.io/pypi/status/typedjsonrpc
+     :target: https://pypi.python.org/pypi/typedjsonrpc
 
 .. image:: https://img.shields.io/pypi/l/typedjsonrpc.svg
-     :target: https://img.shields.io/pypi/l/typedjsonrpc
+     :target: https://pypi.python.org/pypi/typedjsonrpc
 
 .. image:: https://img.shields.io/pypi/pyversions/typedjsonrpc.svg
-     :target: https://img.shields.io/pypi/pyversions/typedjsonrpc
+     :target: https://pypi.python.org/pypi/typedjsonrpc
 
 .. image:: https://img.shields.io/pypi/wheel/typedjsonrpc.svg
-     :target: https://img.shields.io/pypi/wheel/typedjsonrpc
+     :target: https://pypi.python.org/pypi/typedjsonrpc
 
 .. image:: https://badge.fury.io/py/typedjsonrpc.svg
      :target: http://badge.fury.io/py/typedjsonrpc


### PR DESCRIPTION
I noticed that your badges were pointing at `https://img.shields.io/pypi/pyversions/typedjsonrpc`, which returns a 404. Most other repos that use shields.io make their badges link to their package on PyPI ([example](https://github.com/tartley/colorama/blob/master/README.rst)), so that is what I did,